### PR TITLE
Hold reference to Memory passed to zmq_msg_init_data until message is sent

### DIFF
--- a/src/main/java/org/zeromq/zmq_free_fn.java
+++ b/src/main/java/org/zeromq/zmq_free_fn.java
@@ -18,5 +18,6 @@ package org.zeromq;
 import com.sun.jna.*;
 import com.sun.jna.ptr.*;
 
-public class zmq_free_fn extends PointerType {
+public interface zmq_free_fn extends Callback {
+  void invoke(Pointer data, Pointer memory);
 }


### PR DESCRIPTION
When sending PUSH/PULL messages in a akka-zeromq app I discovered some of our ZeroMQ messages were arriving at their destination with contents corrupted.

A question to the zeromq-dev mailing list seemed to identify the problem:

http://lists.zeromq.org/pipermail/zeromq-dev/2012-April/016873.html

Looks like the problem is here:

https://github.com/kro/zeromq-scala-binding/blob/master/src/main/java/org/zeromq/ZMQ.java#L434

There's no reference kept to the memory allocated for the message buffer, so it some cases it seems to get GC'd before the message is actually sent.

This fix is working for me. Where we were once seeing corrupted messages we're now seeing all messages arrive intact.

It also seems to also fix the dropped messages noticed here:

http://groups.google.com/group/akka-user/browse_thread/thread/590b5b1dfcb168c4/805388332289c427?lnk=gst&q=zeromq#805388332289c427 

I ran the benchmarks mentioned in that thread repeatedly with no lost messages.
