### PR TITLE
Throw exception if either bind or connect fails.

### DIFF
--- a/src/main/scala/org/zeromq/ZeroMQLibrary.scala
+++ b/src/main/scala/org/zeromq/ZeroMQLibrary.scala
@@ -513,13 +513,23 @@ object ZMQ {
      * Binds this Socket to an address
      * @param addr the address to bind to, according to: http://api.zeromq.org/2-1:zmq-bind
      */
-    def bind(addr: String): Unit = zmq.zmq_bind(ptr, addr)
+    def bind(addr: String): Unit = {
+      if (zmq.zmq_bind(ptr, addr) != 0) {
+        val errno = zmq.zmq_errno
+        throw new ZMQException(zmq.zmq_strerror(errno), errno)
+      }
+    }
 
     /**
      * Connects this Socket to an address
      * @param addr the address to connect to, according to: http://api.zeromq.org/2-1:zmq-connect
      */
-    def connect(addr: String): Unit = zmq.zmq_connect(ptr, addr)
+    def connect(addr: String): Unit = {
+      if (zmq.zmq_connect(ptr, addr) != 0) {
+        val errno = zmq.zmq_errno
+        throw new ZMQException(zmq.zmq_strerror(errno), errno)
+      }
+    }
 
     /**
      * Sends the given message to this Socket, see the following for more details: http://api.zeromq.org/2-1:zmq-send

--- a/src/test/scala/org/zeromq/ZMQSpec.scala
+++ b/src/test/scala/org/zeromq/ZMQSpec.scala
@@ -27,6 +27,22 @@ class ZMQSpec extends WordSpec with MustMatchers {
       sub.getType must equal(ZMQ.SUB)
       sub.close()
     }
+    "raise error if connect fails" in {
+      val context = ZMQ.context(1)
+      val sub = context.socket(ZMQ.SUB)
+      intercept[ZMQException] {
+        sub.connect("inproc://zmq-spec")
+      }
+      sub.close()
+    }
+    "raise error if bind fails" in {
+      val context = ZMQ.context(1)
+      val sub = context.socket(ZMQ.SUB)
+      intercept[ZMQException] {
+        sub.bind("bad-address")
+      }
+      sub.close()
+    }
     "support pub-sub connection pattern" in {
       val context = ZMQ.context(1)
       val (pub, sub, poller) = (context.socket(ZMQ.PUB),  context.socket(ZMQ.SUB),  context.poller)


### PR DESCRIPTION
Right now, feedback from calls to zmq_bind and zmq_connect is swallowed by the library. Without this feedback, it is very difficult to notice bind/connect problems in running applications.
