### PR TITLE
Support build with both Scala 2.10 and 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,14 +4,14 @@ name := "zeromq-scala-binding"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.10.0"
+val requestedScalaVersion = System.getProperty("zeromq-scala-binding.scalaVersion", "2.10.4")
 
-scalaBinaryVersion <<= scalaVersion
+scalaVersion := requestedScalaVersion
 
 libraryDependencies ++= Seq(
   "net.java.dev.jna" %  "jna"           % "3.0.9",
   "com.github.jnr"   %  "jnr-constants" % "0.8.2",
-  "org.scalatest"    %  "scalatest_2.10"     % "2.0.M5b" % "test"
+  "org.scalatest"    %%  "scalatest"    % "2.1.3" % "test"
 )
 
 scalacOptions := Seq("-deprecation", "-unchecked")

--- a/src/test/scala/org/zeromq/ZMQSpec.scala
+++ b/src/test/scala/org/zeromq/ZMQSpec.scala
@@ -16,15 +16,15 @@
 package org.zeromq
 
 import org.scalatest.WordSpec
-import org.scalatest.matchers.MustMatchers
+import org.scalatest.Matchers
 import org.zeromq.ZMQ._
 
-class ZMQSpec extends WordSpec with MustMatchers {
+class ZMQSpec extends WordSpec with Matchers {
   "ZMQ" must {
     "support Socket#getType" in {
       val context = ZMQ.context(1)
       val sub = context.socket(ZMQ.SUB)
-      sub.getType must equal(ZMQ.SUB)
+      sub.getType should equal(ZMQ.SUB)
       sub.close()
     }
     "raise error if connect fails" in {
@@ -51,10 +51,10 @@ class ZMQSpec extends WordSpec with MustMatchers {
       sub.subscribe(Array.empty)
       poller.register(sub)
       pub.send(outgoingMessage, 0)
-      poller.poll must equal(1)
-      poller.pollin(0) must equal(true)
+      poller.poll should equal(1)
+      poller.pollin(0) should equal(true)
       val incomingMessage = sub.recv(0)
-      incomingMessage must equal(outgoingMessage)
+      incomingMessage should equal(outgoingMessage)
       sub.close()
       pub.close()
     }
@@ -65,9 +65,9 @@ class ZMQSpec extends WordSpec with MustMatchers {
       val subs = 1 to 100 map { _ => connectSubscriber(context) }
       subs foreach poller.register
       pub.send(outgoingMessage, 0)
-      poller.poll must equal(subs.size)
-      subs.indices foreach { i => poller.pollin(i) must be(true) }
-      subs foreach { _.recv(ZMQ.NOBLOCK) must equal(outgoingMessage) }
+      poller.poll should equal(subs.size)
+      subs.indices foreach { i => poller.pollin(i) should be(true) }
+      subs foreach { _.recv(ZMQ.NOBLOCK) should equal(outgoingMessage) }
       subs foreach { _.close() }
       pub.close()
     }
@@ -87,8 +87,8 @@ class ZMQSpec extends WordSpec with MustMatchers {
 
       rep.bind(url)
 
-      rep.getSendTimeOut must equal(timeout)
-      rep.getReceiveTimeOut must equal(timeout)
+      rep.getSendTimeOut should equal(timeout)
+      rep.getReceiveTimeOut should equal(timeout)
       rep.close()
     }
     "support setting the high water mark" in {
@@ -100,7 +100,7 @@ class ZMQSpec extends WordSpec with MustMatchers {
 
       rep.bind(url)
 
-      rep.getHWM() must equal(hwq)
+      rep.getHWM() should equal(hwq)
       rep.close()
     }
     "support setting the rate" in {
@@ -112,7 +112,7 @@ class ZMQSpec extends WordSpec with MustMatchers {
 
       rep.bind(url)
 
-      rep.getRate() must equal(rate)
+      rep.getRate() should equal(rate)
       rep.close()
     }
     "support setting linger" in {
@@ -124,7 +124,7 @@ class ZMQSpec extends WordSpec with MustMatchers {
 
       rep.bind(url)
 
-      rep.getLinger() must equal(linger)
+      rep.getLinger() should equal(linger)
       rep.close()
     }
 
@@ -139,8 +139,8 @@ class ZMQSpec extends WordSpec with MustMatchers {
       rep.setReconnectIVLMax(rivlMax)
       rep.bind(url)
 
-      rep.getReconnectIVL() must equal(rivl)
-      rep.getReconnectIVLMax() must equal(rivlMax)
+      rep.getReconnectIVL() should equal(rivl)
+      rep.getReconnectIVLMax() should equal(rivlMax)
       rep.close()
     }
 
@@ -153,7 +153,7 @@ class ZMQSpec extends WordSpec with MustMatchers {
       rep.setBacklog(backlog)
       rep.bind(url)
 
-      rep.getBacklog() must equal(backlog)
+      rep.getBacklog() should equal(backlog)
       rep.close()
     }
   }

--- a/src/test/scala/org/zeromq/ZeroMQLibrarySpec.scala
+++ b/src/test/scala/org/zeromq/ZeroMQLibrarySpec.scala
@@ -19,11 +19,11 @@ import com.sun.jna.ptr.LongByReference
 import com.sun.jna.{Memory, NativeLong, Pointer}
 import java.util.concurrent.{Executors, TimeUnit}
 import org.scalatest.{BeforeAndAfter, WordSpec}
-import org.scalatest.matchers.MustMatchers
+import org.scalatest.Matchers
 import org.zeromq.ZeroMQ._
 import scala.util.Random
 
-class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
+class ZeroMQLibrarySpec extends WordSpec with Matchers with BeforeAndAfter {
   "ZeroMQLibrary" must {
     var zmq: ZeroMQLibrary = null
     var endpoint: String = null
@@ -34,19 +34,19 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
     "zmq_bind" in {
       val context = zmq.zmq_init(1)
       val socket = zmq.zmq_socket(context, ZMQ_PUB)
-      zmq.zmq_bind(socket, endpoint) must equal(0)
+      zmq.zmq_bind(socket, endpoint) should equal(0)
       zmq.zmq_close(socket)
     }
     "zmq_close" in { 
       val context = zmq.zmq_init(1)
       val socket = zmq.zmq_socket(context, ZMQ_PUB)
-      zmq.zmq_close(socket) must equal(0)
+      zmq.zmq_close(socket) should equal(0)
     }
     "zmq_connect" in {
       val context = zmq.zmq_init(1)
       val (pub, sub) = (zmq.zmq_socket(context, ZMQ_PUB), zmq.zmq_socket(context, ZMQ_SUB))
       zmq.zmq_bind(pub, endpoint)
-      zmq.zmq_connect(sub, endpoint) must equal(0)
+      zmq.zmq_connect(sub, endpoint) should equal(0)
       zmq.zmq_close(sub)
       zmq.zmq_close(pub)
     }
@@ -57,14 +57,14 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
       zmq.zmq_bind(backend, "tcp://127.0.0.1:" + randomPort)
       val executor = Executors.newSingleThreadScheduledExecutor
       executor.schedule(new Runnable { def run { zmq.zmq_term(context) } }, 1, TimeUnit.SECONDS)
-      zmq.zmq_device(ZMQ_QUEUE, frontend, backend) must equal(-1)
-      zmq.zmq_errno must equal(ZeroMQ.ETERM)
+      zmq.zmq_device(ZMQ_QUEUE, frontend, backend) should equal(-1)
+      zmq.zmq_errno should equal(ZeroMQ.ETERM)
       zmq.zmq_close(frontend)
       zmq.zmq_close(backend)
     }
     "zmq_errno" in { 
       zmq.zmq_init(-1)
-      zmq.zmq_errno must equal(EINVAL)
+      zmq.zmq_errno should equal(EINVAL)
     }
     "zmq_(get|set)sockopt" in {
       val context = zmq.zmq_init(1)
@@ -72,25 +72,25 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
       val (offset, sizeInBytes, optionValue) = (0, 8, 1234)
       val value = new Memory(sizeInBytes) { setInt(offset, optionValue) }
       val (length, lengthRef) = (new NativeLong(sizeInBytes), new LongByReference(sizeInBytes))
-      zmq.zmq_setsockopt(socket, ZMQ_HWM, value, length) must equal(0)
-      zmq.zmq_getsockopt(socket, ZMQ_HWM, value, lengthRef) must equal(0)
-      value.getInt(offset) must equal(optionValue)
+      zmq.zmq_setsockopt(socket, ZMQ_HWM, value, length) should equal(0)
+      zmq.zmq_getsockopt(socket, ZMQ_HWM, value, lengthRef) should equal(0)
+      value.getInt(offset) should equal(optionValue)
       zmq.zmq_close(socket)
     }
     "zmq_init" in { 
       val context = zmq.zmq_init(1)
-      context must not be (null)
+      context should not be (null)
     }
     "zmq_msg_close" in {
       val msg = new zmq_msg_t
       zmq.zmq_msg_init(msg)
-      zmq.zmq_msg_close(msg) must equal(0)
+      zmq.zmq_msg_close(msg) should equal(0)
     }
     "zmq_msg_copy" in {
       val (dst, src) = (new zmq_msg_t, new zmq_msg_t)
       zmq.zmq_msg_init_data(src, dataMemory, new NativeLong(dataBytes.length), null, null)
-      zmq.zmq_msg_init_size(dst, new NativeLong(dataBytes.length)) must equal(0)
-      zmq.zmq_msg_copy(dst, src) must equal(0)
+      zmq.zmq_msg_init_size(dst, new NativeLong(dataBytes.length)) should equal(0)
+      zmq.zmq_msg_copy(dst, src) should equal(0)
       zmq.zmq_msg_close(dst)
       zmq.zmq_msg_close(src)
     }
@@ -98,36 +98,36 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
       val msg = new zmq_msg_t
       zmq.zmq_msg_init(msg)
       zmq.zmq_msg_init_data(msg, dataMemory, new NativeLong(dataBytes.length), null, null)
-      zmq.zmq_msg_data(msg).getByteArray(0, dataBytes.length) must equal(dataBytes)
+      zmq.zmq_msg_data(msg).getByteArray(0, dataBytes.length) should equal(dataBytes)
       zmq.zmq_msg_close(msg)
     }
     "zmq_msg_init_data" in { 
       val msg = new zmq_msg_t
-      zmq.zmq_msg_init_data(msg, dataMemory, new NativeLong(dataBytes.length), null, null) must equal(0)
+      zmq.zmq_msg_init_data(msg, dataMemory, new NativeLong(dataBytes.length), null, null) should equal(0)
       zmq.zmq_msg_close(msg)
     }
     "zmq_msg_init_size" in { 
       val msg = new zmq_msg_t
-      zmq.zmq_msg_init_size(msg, new NativeLong(dataBytes.length)) must equal(0)
+      zmq.zmq_msg_init_size(msg, new NativeLong(dataBytes.length)) should equal(0)
       zmq.zmq_msg_close(msg)
     }
     "zmq_msg_init" in {
       val msg = new zmq_msg_t
-      zmq.zmq_msg_init(msg) must equal(0)
+      zmq.zmq_msg_init(msg) should equal(0)
       zmq.zmq_msg_close(msg)
     }
     "zmq_msg_move" in { 
       val (dst, src) = (new zmq_msg_t, new zmq_msg_t)
       zmq.zmq_msg_init_data(src, dataMemory, new NativeLong(dataBytes.length), null, null)
       zmq.zmq_msg_init(dst)
-      zmq.zmq_msg_move(dst, src) must equal(0)
+      zmq.zmq_msg_move(dst, src) should equal(0)
       zmq.zmq_msg_close(dst)
       zmq.zmq_msg_close(src)
     }
     "zmq_msg_size" in {
       val msg = new zmq_msg_t
       zmq.zmq_msg_init_size(msg, new NativeLong(dataBytes.length))
-      zmq.zmq_msg_size(msg) must equal(dataBytes.length)
+      zmq.zmq_msg_size(msg) should equal(dataBytes.length)
       zmq.zmq_msg_close(msg)
     }
     "zmq_(poll|send|recv)" in { 
@@ -139,15 +139,15 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
       val (outgoingMsg, incomingMsg) = (new zmq_msg_t, new zmq_msg_t)
       zmq.zmq_msg_init_data(outgoingMsg, dataMemory, new NativeLong(dataBytes.length), null, null)
       zmq.zmq_msg_init(incomingMsg)
-      zmq.zmq_recv(sub, incomingMsg, ZMQ_NOBLOCK) must equal(-1)
-      zmq.zmq_errno must equal(EAGAIN)
-      zmq.zmq_send(pub, outgoingMsg, 0) must equal(0)
+      zmq.zmq_recv(sub, incomingMsg, ZMQ_NOBLOCK) should equal(-1)
+      zmq.zmq_errno should equal(EAGAIN)
+      zmq.zmq_send(pub, outgoingMsg, 0) should equal(0)
       val items = new zmq_pollitem_t().toArray(1).asInstanceOf[Array[zmq_pollitem_t]]
       items(0) = new zmq_pollitem_t
       items(0).socket = sub
       items(0).events = ZMQ_POLLIN
-      zmq.zmq_poll(items, 1, new NativeLong(-1)) must equal(1)
-      zmq.zmq_recv(sub, incomingMsg, 0) must equal(0)
+      zmq.zmq_poll(items, 1, new NativeLong(-1)) should equal(1)
+      zmq.zmq_recv(sub, incomingMsg, 0) should equal(0)
       zmq.zmq_msg_close(outgoingMsg)
       zmq.zmq_close(sub)
       zmq.zmq_close(pub)
@@ -155,22 +155,22 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
     "zmq_socket" in { 
       val context = zmq.zmq_init(1)
       val socket = zmq.zmq_socket(context, ZMQ_PUB)
-      socket must not be (null)
+      socket should not be (null)
     }
     "zmq_strerror" in { 
       zmq.zmq_init(-1)
-      zmq.zmq_strerror(ETERM) must equal("Context was terminated")
+      zmq.zmq_strerror(ETERM) should equal("Context was terminated")
     }
     "zmq_term" in { 
       val context = zmq.zmq_init(1)
-      zmq.zmq_term(context) must equal(0)
+      zmq.zmq_term(context) should equal(0)
     }
     "zmq_version" in {
       val (major_x, minor_x, patch_x) = (Array(1), Array(1), Array(1))
       val (major_y, minor_y, patch_y) = (Array(1), Array(1), Array(1))
       zmq.zmq_version(major_x, minor_x, patch_x)
       zmq.zmq_version(major_y, minor_y, patch_y)
-      (major_x(0), minor_x(0), patch_x(0)) must equal(major_y(0), minor_y(0), patch_y(0))
+      (major_x(0), minor_x(0), patch_x(0)) should equal(major_y(0), minor_y(0), patch_y(0))
     }
   }
   def randomPort = 1024 + new Random(System.currentTimeMillis).nextInt(4096)


### PR DESCRIPTION
- default is Scala 2.10.4, but you can build for 2.11 with
  sbt -Dzeromq-scala-binding.scalaVersion
- scalatest 2.1.3, and some adjustments of tests (deprecations)
