### PR TITLE
Support for zeromq >= 3.2 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /project
 /target
 tags
+.idea
+.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -4,14 +4,15 @@ name := "zeromq-scala-binding"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.10.0"
+scalaVersion := "2.11.2"
 
 scalaBinaryVersion <<= scalaVersion
 
 libraryDependencies ++= Seq(
   "net.java.dev.jna" %  "jna"           % "3.0.9",
   "com.github.jnr"   %  "jnr-constants" % "0.8.2",
-  "org.scalatest"    %  "scalatest_2.10"     % "2.0.M5b" % "test"
+  "org.scala-lang.modules" % "scala-xml_2.11" % "1.0.2",
+  "org.scalatest"    %  "scalatest_2.11"     % "2.2.1" % "test"
 )
 
 scalacOptions := Seq("-deprecation", "-unchecked")

--- a/src/main/scala/org/zeromq/ZeroMQLibrary.scala
+++ b/src/main/scala/org/zeromq/ZeroMQLibrary.scala
@@ -646,6 +646,9 @@ object ZMQ {
    * @param size the initial size of the Poller, in number of Sockets
    */
   class Poller (context: ZMQ.Context, size: Int) {
+
+    def this(size: Int) = this(null, size)
+
     @BeanProperty var timeout: FiniteDuration = Duration(-1, "ms")
     private var nextEventIndex: Int = 0
     private var maxEventCount: Int = size
@@ -738,12 +741,15 @@ object ZMQ {
      */
     def poll(): Long = poll(this.timeout)
 
+
+    def poll(timeout: Long): Int = poll(1 milliseconds)
+
     /**
      * Polls the registered Sockets using a speficied timeout
      * @param timeout the timeout for the poll operation
      * @return how many items during the poll that yielded revents
      */
-    def poll(timeout: FiniteDuration): Long = {
+    def poll(timeout: FiniteDuration): Int = {
       Arrays.fill(revents, 0, nextEventIndex, 0: Short)
       curEventCount match {
         case 0 ⇒ 0

--- a/src/main/scala/org/zeromq/ZeroMQLibrary.scala
+++ b/src/main/scala/org/zeromq/ZeroMQLibrary.scala
@@ -45,8 +45,9 @@ object ZeroMQ {
   val ZMQ_XSUB   = 10
 
   /** Send / receive options */
-  val ZMQ_NOBLOCK = 1
-  val ZMQ_SNDMORE = 2 
+  val ZMQ_DONTWAIT = 1
+  val ZMQ_SNDMORE = 2
+  val ZMQ_NOBLOCK = ZMQ_DONTWAIT //leaved for backward compatibility
 
   /** Socket options */
   val ZMQ_HWM               = 1

--- a/src/main/scala/org/zeromq/ZeroMQLibrary.scala
+++ b/src/main/scala/org/zeromq/ZeroMQLibrary.scala
@@ -26,7 +26,8 @@ import java.util.{ Arrays, HashSet => JHashSet }
 import java.lang.{ Long ⇒ JLong, Integer ⇒ JInteger }
 import scala.beans.BeanProperty
 import scala.annotation.tailrec
-import concurrent.duration.{Duration, FiniteDuration}
+import concurrent.duration._
+
 
 object ZeroMQ {
 
@@ -102,6 +103,10 @@ object ZeroMQ {
   val ZMQ_POLLOUT = 2: Short
   val ZMQ_POLLERR = 4: Short
 
+  /** Context options */
+  val ZMQ_IO_THREADS =  1
+  val ZMQ_MAX_SOCKETS = 2
+
   def loadLibrary(): ZeroMQLibrary = Native.loadLibrary("zmq", classOf[ZeroMQLibrary]).asInstanceOf[ZeroMQLibrary]
 }
 
@@ -128,6 +133,7 @@ trait ZeroMQLibrary extends Library {
   def zmq_socket(context: Pointer, socket_type: Int): Pointer
   def zmq_strerror(errnum: Int): String
   def zmq_term(context: Pointer): Int
+  def zmq_ctx_set(context: Pointer, option_name: Int, option_value: Int): Boolean
   def zmq_version(major: Array[Int], minor: Array[Int], patch: Array[Int]): Unit
 }
 
@@ -217,6 +223,8 @@ object ZMQ {
      * @return a newly created Poller with the given size
      */
     def poller(size: Int): Poller = new Poller(this, size)
+
+    def setMaxSockets(maxSockets: Int): Boolean = zmq.zmq_ctx_set(ptr, ZeroMQ.ZMQ_MAX_SOCKETS, maxSockets)
   }
 
   private final val versionBelow210 = fullVersion < makeVersion(2, 1, 0)

--- a/src/main/scala/org/zeromq/ZeroMQLibrary.scala
+++ b/src/main/scala/org/zeromq/ZeroMQLibrary.scala
@@ -199,6 +199,9 @@ object ZMQ {
   final val STREAMER = ZeroMQ.ZMQ_STREAMER
   final val FORWARDER = ZeroMQ.ZMQ_FORWARDER
   final val QUEUE = ZeroMQ.ZMQ_QUEUE
+  final val XPUB = ZeroMQ.ZMQ_XPUB
+  final val XSUB = ZeroMQ.ZMQ_XSUB
+
 
   /**
    * Represents a 0MQ Context

--- a/src/main/scala/org/zeromq/ZeroMQLibrary.scala
+++ b/src/main/scala/org/zeromq/ZeroMQLibrary.scala
@@ -550,8 +550,12 @@ object ZMQ {
       if (zmq.zmq_msg_send(message, ptr, flags) < 0) {
         zmq.zmq_msg_close(message)
         raiseZMQException()
-      } else {
+      }
+      else if(zmq.zmq_errno != EAGAIN){
         if (zmq.zmq_msg_close(message) != 0) raiseZMQException() else false
+      }
+      else {
+        if (zmq.zmq_msg_close(message) != 0) raiseZMQException() else true
       }
     }
 

--- a/src/test/scala/org/zeromq/ZMQSpec.scala
+++ b/src/test/scala/org/zeromq/ZMQSpec.scala
@@ -31,7 +31,7 @@ class ZMQSpec extends WordSpec with MustMatchers {
       val context = ZMQ.context(1)
       val sub = context.socket(ZMQ.SUB)
       intercept[ZMQException] {
-        sub.connect("inproc://zmq-spec")
+        sub.connect("tcp://12.bad.ip.0")
       }
       sub.close()
     }
@@ -91,7 +91,7 @@ class ZMQSpec extends WordSpec with MustMatchers {
       rep.getReceiveTimeOut must equal(timeout)
       rep.close()
     }
-    "support setting the high water mark" in {
+    "backward support setting the high water mark" in {
       val context = ZMQ.context(1)
       val rep = context.socket(ZMQ.REP)
       val url = "inproc://zmq-spec"
@@ -99,8 +99,13 @@ class ZMQSpec extends WordSpec with MustMatchers {
       rep.setHWM(hwq)
 
       rep.bind(url)
-
-      rep.getHWM() must equal(hwq)
+      if(ZMQ.fullVersion >= makeVersion(3, 0, 0)) {
+        rep.getSndHWM() must equal(hwq)
+        rep.getRcvHWM() must equal(hwq)
+      }
+      else{
+        rep.getHWM() must equal(hwq)
+      }
       rep.close()
     }
     "support setting the rate" in {

--- a/src/test/scala/org/zeromq/ZeroMQLibrarySpec.scala
+++ b/src/test/scala/org/zeromq/ZeroMQLibrarySpec.scala
@@ -139,15 +139,15 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
       val (outgoingMsg, incomingMsg) = (new zmq_msg_t, new zmq_msg_t)
       zmq.zmq_msg_init_data(outgoingMsg, dataMemory, new NativeLong(dataBytes.length), null, null)
       zmq.zmq_msg_init(incomingMsg)
-      zmq.zmq_recv(sub, incomingMsg, ZMQ_NOBLOCK) must equal(-1)
+      zmq.zmq_msg_recv(incomingMsg, sub, ZMQ_NOBLOCK) must equal(-1)
       zmq.zmq_errno must equal(EAGAIN)
-      zmq.zmq_send(pub, outgoingMsg, 0) must equal(0)
+      zmq.zmq_msg_send(outgoingMsg,pub, 0) must equal(0)
       val items = new zmq_pollitem_t().toArray(1).asInstanceOf[Array[zmq_pollitem_t]]
       items(0) = new zmq_pollitem_t
       items(0).socket = sub
       items(0).events = ZMQ_POLLIN
       zmq.zmq_poll(items, 1, new NativeLong(-1)) must equal(1)
-      zmq.zmq_recv(sub, incomingMsg, 0) must equal(0)
+      zmq.zmq_msg_recv(incomingMsg, sub, 0) must equal(0)
       zmq.zmq_msg_close(outgoingMsg)
       zmq.zmq_close(sub)
       zmq.zmq_close(pub)

--- a/src/test/scala/org/zeromq/ZeroMQLibrarySpec.scala
+++ b/src/test/scala/org/zeromq/ZeroMQLibrarySpec.scala
@@ -15,7 +15,7 @@
  */
 package org.zeromq
 
-import com.sun.jna.ptr.LongByReference
+import com.sun.jna.ptr.{LongByReference, IntByReference}
 import com.sun.jna.{Memory, NativeLong, Pointer}
 import java.util.concurrent.{Executors, TimeUnit}
 import org.scalatest.{BeforeAndAfter, WordSpec}
@@ -71,9 +71,9 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
       val socket = zmq.zmq_socket(context, ZMQ_PUB)
       val (offset, sizeInBytes, optionValue) = (0, 8, 1234)
       val value = new Memory(sizeInBytes) { setInt(offset, optionValue) }
-      val (length, lengthRef) = (new NativeLong(sizeInBytes), new LongByReference(sizeInBytes))
-      zmq.zmq_setsockopt(socket, ZMQ_HWM, value, length) must equal(0)
-      zmq.zmq_getsockopt(socket, ZMQ_HWM, value, lengthRef) must equal(0)
+      val (length, lengthRef) =  (new NativeLong(Integer.SIZE / 8), new LongByReference(Integer.SIZE / 8))
+      zmq.zmq_setsockopt(socket, ZMQ_SNDHWM, value, length) must equal(0)
+      zmq.zmq_getsockopt(socket, ZMQ_SNDHWM, value, lengthRef) must equal(0)
       value.getInt(offset) must equal(optionValue)
       zmq.zmq_close(socket)
     }
@@ -141,13 +141,13 @@ class ZeroMQLibrarySpec extends WordSpec with MustMatchers with BeforeAndAfter {
       zmq.zmq_msg_init(incomingMsg)
       zmq.zmq_msg_recv(incomingMsg, sub, ZMQ_NOBLOCK) must equal(-1)
       zmq.zmq_errno must equal(EAGAIN)
-      zmq.zmq_msg_send(outgoingMsg,pub, 0) must equal(0)
+      zmq.zmq_msg_send(outgoingMsg,pub, 0) must be > 0
       val items = new zmq_pollitem_t().toArray(1).asInstanceOf[Array[zmq_pollitem_t]]
       items(0) = new zmq_pollitem_t
       items(0).socket = sub
       items(0).events = ZMQ_POLLIN
       zmq.zmq_poll(items, 1, new NativeLong(-1)) must equal(1)
-      zmq.zmq_msg_recv(incomingMsg, sub, 0) must equal(0)
+      zmq.zmq_msg_recv(incomingMsg, sub, 0) must be > 0
       zmq.zmq_msg_close(outgoingMsg)
       zmq.zmq_close(sub)
       zmq.zmq_close(pub)


### PR DESCRIPTION
Hi,
I have followed the guidelines for [upgrading to 3.2](http://zeromq.org/docs:3-1-upgrade). I have tested all unit tests and with my own applications on Mac OS X 10.10 with ZeroMQ 4.1.0. 

I would like to keep this project moving forward as an alternative to jzmq.

Let me know if there is anything else in which I can contribute.

Thanks,
Alex

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/valotrading/zeromq-scala-binding/28)

<!-- Reviewable:end -->
